### PR TITLE
Allow Figma scene to be resized without error

### DIFF
--- a/examples/scenes/src/FigmaScene.java
+++ b/examples/scenes/src/FigmaScene.java
@@ -105,6 +105,8 @@ public class FigmaScene extends Scene {
 
     @Override
     public void draw(Canvas canvas, int width, int height, float dpi, int xpos, int ypos) {
+        if (width < 700) { width = 700; }
+        if (height < 700) { height = 700; }
         drawTabbar(canvas, width, height);
         drawToolbar(canvas, width, height);
         drawLeft(canvas, width, height, dpi);


### PR DESCRIPTION
Resizing the window for Figma example to extreme dimensions (eg., zero height, or zero width) can throw an error and freeze the UI, this seems to fix it.