### PR TITLE
fix #6: Upgrade LWJGL to 3.3.1

### DIFF
--- a/examples/clojure-snake/deps.edn
+++ b/examples/clojure-snake/deps.edn
@@ -1,33 +1,55 @@
 {
   :deps {
     org.clojure/clojure      {:mvn/version "1.10.3"}
-    org.lwjgl/lwjgl          {:mvn/version "3.2.3"}
-    org.lwjgl/lwjgl-glfw     {:mvn/version "3.2.3"}
-    org.lwjgl/lwjgl-opengl   {:mvn/version "3.2.3"}
+    org.lwjgl/lwjgl          {:mvn/version "3.3.1"}
+    org.lwjgl/lwjgl-glfw     {:mvn/version "3.3.1"}
+    org.lwjgl/lwjgl-opengl   {:mvn/version "3.3.1"}
     io.github.humbleui/types {:mvn/version "0.1.2"}
   }
   :paths ["src" "../../shared/target/classes-java9" "../../shared/target/classes"]
   :aliases {
-    :macos {
+    :macos-x64 {
       :extra-deps {
-        org.lwjgl/lwjgl$natives-macos        {:mvn/version "3.2.3"}
-        org.lwjgl/lwjgl-glfw$natives-macos   {:mvn/version "3.2.3"}
-        org.lwjgl/lwjgl-opengl$natives-macos {:mvn/version "3.2.3"}
+        org.lwjgl/lwjgl$natives-macos        {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-glfw$natives-macos   {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-opengl$natives-macos {:mvn/version "3.3.1"}
       }
       :jvm-opts ["-XstartOnFirstThread"]
     }
-    :windows {
+    :macos-arm64 {
       :extra-deps {
-        org.lwjgl/lwjgl$natives-windows        {:mvn/version "3.2.3"}
-        org.lwjgl/lwjgl-glfw$natives-windows   {:mvn/version "3.2.3"}
-        org.lwjgl/lwjgl-opengl$natives-windows {:mvn/version "3.2.3"}
+        org.lwjgl/lwjgl$natives-macos-arm64        {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-glfw$natives-macos-arm64   {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-opengl$natives-macos-arm64 {:mvn/version "3.3.1"}
+      }
+      :jvm-opts ["-XstartOnFirstThread"]
+    }
+    :windows-x64 {
+      :extra-deps {
+        org.lwjgl/lwjgl$natives-windows        {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-glfw$natives-windows   {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-opengl$natives-windows {:mvn/version "3.3.1"}
       }
     }
-    :linux {
+    :windows-arm64 {
       :extra-deps {
-        org.lwjgl/lwjgl$natives-linux        {:mvn/version "3.2.3"}
-        org.lwjgl/lwjgl-glfw$natives-linux   {:mvn/version "3.2.3"}
-        org.lwjgl/lwjgl-opengl$natives-linux {:mvn/version "3.2.3"}
+        org.lwjgl/lwjgl$natives-windows-arm64        {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-glfw$natives-windows-arm64   {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-opengl$natives-windows-arm64 {:mvn/version "3.3.1"}
+      }
+    }
+    :linux-x64 {
+      :extra-deps {
+        org.lwjgl/lwjgl$natives-linux        {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-glfw$natives-linux   {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-opengl$natives-linux {:mvn/version "3.3.1"}
+      }
+    }
+    :linux-arm64 {
+      :extra-deps {
+        org.lwjgl/lwjgl$natives-linux-arm64        {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-glfw$natives-linux-arm64   {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-opengl$natives-linux-arm64 {:mvn/version "3.3.1"}
       }
     }
   }

--- a/examples/clojure-snake/script/run.py
+++ b/examples/clojure-snake/script/run.py
@@ -8,7 +8,7 @@ def main():
   subprocess.check_call([
     "clj",
     "-J--module-path=" + os.path.join('..', '..', 'platform', 'target', common.classifier, 'classes'),
-    "-M:" + build_utils.system,
+    "-M:" + common.classifier,
     "-m", "snake.main"])
   return 0
 

--- a/examples/clojure/deps.edn
+++ b/examples/clojure/deps.edn
@@ -1,34 +1,56 @@
 {
   :deps {
     org.clojure/clojure      {:mvn/version "1.11.1"}
-    org.lwjgl/lwjgl          {:mvn/version "3.2.3"}
-    org.lwjgl/lwjgl-glfw     {:mvn/version "3.2.3"}
-    org.lwjgl/lwjgl-opengl   {:mvn/version "3.2.3"}
+    org.lwjgl/lwjgl          {:mvn/version "3.3.1"}
+    org.lwjgl/lwjgl-glfw     {:mvn/version "3.3.1"}
+    org.lwjgl/lwjgl-opengl   {:mvn/version "3.3.1"}
     nrepl/nrepl              {:mvn/version "0.8.3"}
     io.github.humbleui/types {:mvn/version "0.1.2"}
   }
   :paths ["src" "../../shared/target/classes-java9" "../../shared/target/classes" ]
   :aliases {
-    :macos {
+    :macos-x64 {
       :extra-deps {
-        org.lwjgl/lwjgl$natives-macos        {:mvn/version "3.2.3"}
-        org.lwjgl/lwjgl-glfw$natives-macos   {:mvn/version "3.2.3"}
-        org.lwjgl/lwjgl-opengl$natives-macos {:mvn/version "3.2.3"}
+        org.lwjgl/lwjgl$natives-macos        {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-glfw$natives-macos   {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-opengl$natives-macos {:mvn/version "3.3.1"}
       }
       :jvm-opts ["-XstartOnFirstThread"]
     }
-    :windows {
+    :macos-arm64 {
       :extra-deps {
-        org.lwjgl/lwjgl$natives-windows        {:mvn/version "3.2.3"}
-        org.lwjgl/lwjgl-glfw$natives-windows   {:mvn/version "3.2.3"}
-        org.lwjgl/lwjgl-opengl$natives-windows {:mvn/version "3.2.3"}
+        org.lwjgl/lwjgl$natives-macos-arm64        {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-glfw$natives-macos-arm64   {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-opengl$natives-macos-arm64 {:mvn/version "3.3.1"}
+      }
+      :jvm-opts ["-XstartOnFirstThread"]
+    }
+    :windows-x64 {
+      :extra-deps {
+        org.lwjgl/lwjgl$natives-windows        {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-glfw$natives-windows   {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-opengl$natives-windows {:mvn/version "3.3.1"}
       }
     }
-    :linux {
+    :windows-arm64 {
       :extra-deps {
-        org.lwjgl/lwjgl$natives-linux        {:mvn/version "3.2.3"}
-        org.lwjgl/lwjgl-glfw$natives-linux   {:mvn/version "3.2.3"}
-        org.lwjgl/lwjgl-opengl$natives-linux {:mvn/version "3.2.3"}
+        org.lwjgl/lwjgl$natives-windows-arm64        {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-glfw$natives-windows-arm64   {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-opengl$natives-windows-arm64 {:mvn/version "3.3.1"}
+      }
+    }
+    :linux-x64 {
+      :extra-deps {
+        org.lwjgl/lwjgl$natives-linux        {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-glfw$natives-linux   {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-opengl$natives-linux {:mvn/version "3.3.1"}
+      }
+    }
+    :linux-arm64 {
+      :extra-deps {
+        org.lwjgl/lwjgl$natives-linux-arm64        {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-glfw$natives-linux-arm64   {:mvn/version "3.3.1"}
+        org.lwjgl/lwjgl-opengl$natives-linux-arm64 {:mvn/version "3.3.1"}
       }
     }
   }

--- a/examples/clojure/script/run.py
+++ b/examples/clojure/script/run.py
@@ -8,7 +8,7 @@ def main():
   subprocess.check_call([
     "clj",
     "-J--module-path=" + os.path.join('..', '..', 'platform', 'target', common.classifier, 'classes'),
-    "-M:" + build_utils.system,
+    "-M:" + common.classifier,
     "-m", "lwjgl.main"])
   return 0
 

--- a/examples/lwjgl/script/run.py
+++ b/examples/lwjgl/script/run.py
@@ -6,11 +6,15 @@ import common, build, build_utils
 def main():
   parser = argparse.ArgumentParser()
   parser.add_argument('--skija-version')
-  parser.add_argument('--lwjgl-version', default='3.2.3')
+  parser.add_argument('--lwjgl-version', default='3.3.1')
   (args, _) = parser.parse_known_args()
 
   # Javac
-  lwjgl_classifier = "natives-" + build_utils.system
+  if (build_utils.arch == 'x64'):
+    lwjgl_classifier = "natives-" + build_utils.system
+  else:
+    lwjgl_classifier = "natives-" + common.classifier
+
   classpath = common.deps_compile() + [
     build_utils.fetch_maven('org.lwjgl', 'lwjgl', args.lwjgl_version),
     build_utils.fetch_maven('org.lwjgl', 'lwjgl-glfw', args.lwjgl_version),


### PR DESCRIPTION
Upgrade LWJGL to allow run LWJGL examples on the Apple Silicon machine.

![image](https://user-images.githubusercontent.com/20694662/209863012-3a36fe5f-53eb-4cc2-9ee9-7c9e05bfbe2f.png)
