### PR TITLE
Bump lombok from 1.18.22 to 1.18.26

### DIFF
--- a/script/build_utils.py
+++ b/script/build_utils.py
@@ -124,7 +124,7 @@ def jar(target: str, *content: List[Tuple[str, str]], opts=[]) -> str:
 
 @functools.lru_cache(maxsize=1)
 def lombok():
-  return fetch_maven('org.projectlombok', 'lombok', '1.18.22')
+  return fetch_maven('org.projectlombok', 'lombok', '1.18.26')
 
 def delombok(dirs: List[str], target: str, classpath: List[str] = [], modulepath: List[str] = []):
   sources = files(*[dir + "/**/*.java" for dir in dirs])

--- a/script/common.py
+++ b/script/common.py
@@ -12,7 +12,7 @@ runtime_deps = [
 
 compile_deps = [
   {'group': 'org.jetbrains', 'name': 'annotations', 'version': '20.1.0'},
-  {'group': 'org.projectlombok', 'name': 'lombok', 'version': '1.18.22'},
+  {'group': 'org.projectlombok', 'name': 'lombok', 'version': '1.18.26'},
 ]
 
 @functools.lru_cache(maxsize=1)


### PR DESCRIPTION
Lombok 1.18.26 is compatible with JDK 19, so I updated it to solve the problem that Skija cannot be compiled using JDK 19.