### PR TITLE
Exclude some useless jars when publishing GitHub Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,6 +134,14 @@ jobs:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+      - name: Delete useless jars
+        run: |
+          rm target/skija-macos-*-sources.jar
+          rm target/skija-macos-*-javadoc.jar
+          rm target/skija-linux-*-sources.jar
+          rm target/skija-linux-*-javadoc.jar
+          rm target/skija-windows-*-sources.jar
+          rm target/skija-windows-*-javadoc.jar
       - uses: softprops/action-gh-release@v1
         with:
           files: |


### PR DESCRIPTION
This PR removes the javadoc and sources jar of the platform jar -- because they are useless empty jars, but retains the ssources and javadoc of shared jar in GitHub Release.

I try to filter them by adjusting the files parameter of action-gh-release, but I don't know why it doesn't work, so I use `rm` to implement this function.