### PR TITLE
Fix (EXCEPTION_ACCESS_VIOLATION) when debugging in IDE due to implicit toString on variables

### DIFF
--- a/shared/java/impl/RefCnt.java
+++ b/shared/java/impl/RefCnt.java
@@ -23,7 +23,10 @@ public abstract class RefCnt extends Managed {
     @Override
     public String toString() {
         String s = super.toString();
-        return s.substring(0, s.length() - 1) + ", refCount=" + getRefCount() + ")";
+        String base = s.substring(0, s.length() - 1); 
+        return base + (isClosed()
+                ? ", object is closed)"
+                : ", refCount=" + getRefCount() + ")");
     }
 
     @ApiStatus.Internal

--- a/tests/java/ImageTest.java
+++ b/tests/java/ImageTest.java
@@ -12,6 +12,10 @@ import io.github.humbleui.skija.test.runner.*;
 public class ImageTest implements Executable {
     @Override
     public void execute() throws Exception {
+        TestRunner.testMethod(this, "base");
+        TestRunner.testMethod(this, "refCntToStringAfterClose");
+    }
+    public void base() throws Exception {
         try (var surface = Surface.makeRasterN32Premul(100, 100);
              var paint = new Paint().setColor(0xFFFF0000);
              var path = new io.github.humbleui.skija.Path().moveTo(20, 80).lineTo(50, 20).lineTo(80, 80).closePath();)
@@ -30,5 +34,18 @@ public class ImageTest implements Executable {
                 Files.write(Path.of(dir, "polygon_webp_lossless.webp"), EncoderWEBP.encode(image,EncodeWEBPOptions.DEFAULT.withCompressionMode(EncodeWEBPCompressionMode.LOSSLESS)).getBytes());
             }
         }
+    }
+
+    public void refCntToStringAfterClose() throws Exception {
+        Bitmap bmp = new Bitmap(); 
+        bmp.allocN32Pixels(10, 20);
+        Image img = Image.makeRasterFromBitmap(bmp);
+        assertEquals(1, img.getRefCount());
+        img.toString();
+        img.close();
+        assertDoesNotThrow(() -> {
+            img.toString();
+        });
+        bmp.close();
     }
 }

--- a/tests/java/runner/TestRunner.java
+++ b/tests/java/runner/TestRunner.java
@@ -204,6 +204,17 @@ public class TestRunner {
                 runner.fail("Expected '" + expected.getName() + "', caught '" + e + "'");
         }
     }
+    
+    public static void assertDoesNotThrow(Executable executable) {
+        runner.asserts++;
+        try {
+            executable.execute();
+            System.out.print(".");
+        } catch (Exception e) {
+            runner.fail("Did not expect exception, but caught '" + e + "'");
+        }
+    }
+
 
     public static void testClass(Class<? extends Executable> cls) {
         pushStack(cls.getName());


### PR DESCRIPTION
### Problem
When debugging in IDEs with variable value rendering (e.g. IntelliJ IDEA, Eclipse), 
the debugger may implicitly call `toString()` on user objects to show their state.  
In some cases this leads to `EXCEPTION_ACCESS_VIOLATION` and process crash.

<img width="960" height="105" alt="image" src="https://github.com/user-attachments/assets/4dd46417-e503-4480-a928-b86201b92281" />

<img width="1003" height="417" alt="issue" src="https://github.com/user-attachments/assets/8201ec77-3423-4f57-9404-fd790086ffc9" />
