### PR TITLE
ColorType enumeration mismatch with native Skia fix

### DIFF
--- a/shared/java/ColorType.java
+++ b/shared/java/ColorType.java
@@ -69,6 +69,11 @@ public enum ColorType {
     BGR_101010X_XR,
 
     /**
+     * Pixel with 10 used bits (most significant) followed by 6 unused bits for red, green, blue, alpha; in 64-bit word
+    */
+    RGBA_10x6,
+
+    /**
      * Pixel with grayscale level in 8-bit byte
      */
     GRAY_8,       
@@ -149,6 +154,8 @@ public enum ColorType {
             case RGB_101010X:        return 4;
             case BGRA_1010102:       return 4;
             case BGR_101010X:        return 4;
+            case BGR_101010X_XR:     return 4;
+            case RGBA_10x6:          return 8;
             case GRAY_8:             return 1;
             case RGBA_F16NORM:       return 8;
             case RGBA_F16:           return 8;
@@ -176,6 +183,8 @@ public enum ColorType {
             case RGB_101010X:        return 2;
             case BGRA_1010102:       return 2;
             case BGR_101010X:        return 2;
+            case BGR_101010X_XR:     return 2;
+            case RGBA_10x6:          return 3;
             case GRAY_8:             return 0;
             case RGBA_F16NORM:       return 3;
             case RGBA_F16:           return 3;
@@ -230,6 +239,7 @@ public enum ColorType {
             case RGBA_F16NORM:
             case RGBA_F16:
             case RGBA_F32:
+            case RGBA_10x6:
             case R16G16B16A16_UNORM:
                 if (ColorAlphaType.UNKNOWN == alphaType)
                     return null;
@@ -242,6 +252,7 @@ public enum ColorType {
             case RGB_888X:
             case RGB_101010X:
             case BGR_101010X:
+            case BGR_101010X_XR:
                 alphaType = ColorAlphaType.OPAQUE;
                 break;
         }

--- a/tests/java/BitmapTest.java
+++ b/tests/java/BitmapTest.java
@@ -2,6 +2,7 @@ package io.github.humbleui.skija.test;
 
 import static io.github.humbleui.skija.test.runner.TestRunner.*;
 
+import io.github.humbleui.skija.ColorType;
 import io.github.humbleui.skija.Bitmap;
 import io.github.humbleui.skija.Canvas;
 import io.github.humbleui.skija.ColorAlphaType;
@@ -14,6 +15,7 @@ public class BitmapTest implements Executable {
         TestRunner.testMethod(this, "base");
         TestRunner.testMethod(this, "swap");
         TestRunner.testMethod(this, "getSurfaceNull");
+        TestRunner.testMethod(this, "colorTypeMapTest");
     }
 
     public void base() throws Exception {
@@ -73,6 +75,19 @@ public class BitmapTest implements Executable {
             Canvas canvas = new Canvas(a);
             assertNull(canvas.getSurface());
             canvas.close();
+        }
+    }
+
+    public void colorTypeMapTest() throws Exception {
+        for (ColorType ct : ColorType.values()) {
+            try (Bitmap bitmap = new Bitmap(); Bitmap dst = new Bitmap()) {
+                bitmap.allocN32Pixels(5, 5);
+                var info = bitmap.getImageInfo().withColorType(ct);
+                boolean ok = dst.allocPixels(info);
+                assertEquals(true, ok);
+                assertEquals(ct, dst.getImageInfo().getColorType());
+                assertEquals((long)(ct.getBytesPerPixel() * 5), dst.getRowBytes());
+            }
         }
     }
 }


### PR DESCRIPTION
ColorType enumeration mismatch with native Skia
Reproduced in the Bitmap.allocPixels method
The current version(master branch) needs to be checked too.

<img width="819" height="382" alt="image" src="https://github.com/user-attachments/assets/fa1cddc2-d8ec-405a-bb08-4d06c04727b7" />
