### PR TITLE
Add Image.makeSubset() method for efficient image cropping

### DIFF
--- a/platform/cc/Image.cc
+++ b/platform/cc/Image.cc
@@ -7,6 +7,7 @@
 #include "include/core/SkShader.h"
 #include "include/gpu/ganesh/GrBackendSurface.h"
 #include "include/gpu/ganesh/GrDirectContext.h"
+#include "include/gpu/ganesh/GrRecordingContext.h"
 #include "include/gpu/ganesh/SkImageGanesh.h"
 #include "include/gpu/ganesh/gl/GrGLBackendSurface.h"
 #include "include/gpu/ganesh/gl/GrGLTypes.h"
@@ -157,6 +158,16 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_github_humbleui_skija_Image__1nMakeSc
                                               static_cast<SkAlphaType>(alphaType),
                                               sk_ref_sp<SkColorSpace>(colorSpace));
     sk_sp<SkImage> image = instance->makeScaled(imageInfo, skija::SamplingMode::unpack(samplingOptions));
+    return image ? ptrToJlong(image.release()) : 0;
+}
+
+extern "C" JNIEXPORT jlong JNICALL Java_io_github_humbleui_skija_Image__1nMakeSubset
+  (JNIEnv* env, jclass jclass, jlong ptr, jlong contextPtr, jint subsetL, jint subsetT, jint subsetR, jint subsetB) {
+    SkImage* instance = reinterpret_cast<SkImage*>(static_cast<uintptr_t>(ptr));
+    GrDirectContext* context = reinterpret_cast<GrDirectContext*>(static_cast<uintptr_t>(contextPtr));
+    SkIRect subset = SkIRect::MakeLTRB(subsetL, subsetT, subsetR, subsetB);
+    SkRecorder* recorder = context ? context->asRecorder() : nullptr;
+    sk_sp<SkImage> image = instance->makeSubset(recorder, subset, SkImage::RequiredProperties());
     return image ? ptrToJlong(image.release()) : 0;
 }
 

--- a/shared/java/Image.java
+++ b/shared/java/Image.java
@@ -449,6 +449,38 @@ public class Image extends RefCnt implements IHasImageInfo {
     }
 
     /**
+     * Returns an Image that is made from subset of this Image.
+     *
+     * @param subset bounds of Image to extract
+     * @return       subset Image or null
+     */
+    @Nullable
+    public Image makeSubset(@NotNull IRect subset) {
+        return makeSubset(null, subset);
+    }
+
+    /**
+     * Returns an Image that is made from subset of this Image.
+     *
+     * @param context the DirectContext in play - if it exists
+     * @param subset  bounds of Image to extract
+     * @return        subset Image or null
+     */
+    @Nullable
+    public Image makeSubset(@Nullable DirectContext context, @NotNull IRect subset) {
+        try {
+            assert subset != null : "Can't makeSubset with subset == null";
+            Stats.onNativeCall();
+            long ptr = _nMakeSubset(_ptr, Native.getPtr(context), subset._left, subset._top, subset._right, subset._bottom);
+            return ptr == 0 ? null : new Image(ptr);
+        } finally {
+            ReferenceUtil.reachabilityFence(this);
+            ReferenceUtil.reachabilityFence(context);
+            ReferenceUtil.reachabilityFence(subset);
+        }
+    }
+
+    /**
      * <p>Creates a filtered Image on the CPU. The filter processes the src image, potentially changing
      * the color, position, and size. The subset parameter defines the bounds of src that are processed
      * by the filter. The clipBounds parameter specifies the expected bounds of the filtered Image.
@@ -546,6 +578,7 @@ public class Image extends RefCnt implements IHasImageInfo {
     @ApiStatus.Internal public static native boolean _nPeekPixelsToPixmap(long ptr, long pixmapPtr);
     @ApiStatus.Internal public static native boolean _nScalePixels(long ptr, long pixmapPtr, long samplingOptions, boolean cache);
     @ApiStatus.Internal public static native long    _nMakeScaled(long ptr, int width, int height, int colorType, int alphaType, long colorSpacePtr, long samplingOptions);
+    @ApiStatus.Internal public static native long    _nMakeSubset(long ptr, long contextPtr, int subsetL, int subsetT, int subsetR, int subsetB);
     @ApiStatus.Internal public static native boolean _nReadPixelsBitmap(long ptr, long contextPtr, long bitmapPtr, int srcX, int srcY, boolean cache);
     @ApiStatus.Internal public static native boolean _nReadPixelsPixmap(long ptr, long pixmapPtr, int srcX, int srcY, boolean cache);
     @ApiStatus.Internal public static native ImageWithFilterResult _nMakeWithFilter(long srcPtr, long filterPtr, int subsetL, int subsetT, int subsetR, int subsetB, int clipBoundsL, int clipBoundsT, int clipBoundsR, int clipBoundsB);

--- a/tests/java/ImageTest.java
+++ b/tests/java/ImageTest.java
@@ -8,11 +8,13 @@ import java.nio.file.Path;
 
 import io.github.humbleui.skija.*;
 import io.github.humbleui.skija.test.runner.*;
+import io.github.humbleui.types.IRect;
 
 public class ImageTest implements Executable {
     @Override
     public void execute() throws Exception {
         TestRunner.testMethod(this, "base");
+        TestRunner.testMethod(this, "makeSubset");
         TestRunner.testMethod(this, "refCntToStringAfterClose");
     }
     public void base() throws Exception {
@@ -32,6 +34,22 @@ public class ImageTest implements Executable {
                 Files.write(Path.of(dir, "polygon_webp_default.webp"), EncoderWEBP.encode(image).getBytes());
                 Files.write(Path.of(dir, "polygon_webp_50.webp"), EncoderWEBP.encode(image,EncodeWEBPOptions.DEFAULT.withQuality(50)).getBytes());
                 Files.write(Path.of(dir, "polygon_webp_lossless.webp"), EncoderWEBP.encode(image,EncodeWEBPOptions.DEFAULT.withCompressionMode(EncodeWEBPCompressionMode.LOSSLESS)).getBytes());
+            }
+        }
+    }
+
+    public void makeSubset() throws Exception {
+        try (var surface = Surface.makeRaster(ImageInfo.makeN32Premul(100, 80))) {
+            var canvas = surface.getCanvas();
+            canvas.clear(0xFF112233);
+            try (var image = surface.makeImageSnapshot()) {
+                var subset = image.makeSubset(new IRect(10, 20, 70, 50));
+                assertNotNull(subset);
+                if (subset != null) {
+                    assertEquals(60, subset.getWidth());
+                    assertEquals(30, subset.getHeight());
+                    subset.close();
+                }
             }
         }
     }


### PR DESCRIPTION
Add Skia's `SkImage::makeSubset()` method, enabling direct cropping of Image objects without intermediate conversions.