### PR TITLE
Add runtime control for DWrite system font rendering params on Windows

### DIFF
--- a/platform/cc/FontMgr.cc
+++ b/platform/cc/FontMgr.cc
@@ -79,3 +79,9 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_github_humbleui_skija_FontMgr__1nDefa
     SkFontMgr* instance = SkFontMgr::RefDefault().release();
     return reinterpret_cast<jlong>(instance);
 }
+
+extern "C" void DWriteTypeface_UseSystemRenderingParams(int value);
+extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_skija_FontMgr__1nUseSystemRenderingParams
+  (JNIEnv* env, jclass jclass, jint value) {
+    DWriteTypeface_UseSystemRenderingParams((int)value);
+}

--- a/shared/java/FontMgr.java
+++ b/shared/java/FontMgr.java
@@ -169,6 +169,23 @@ public class FontMgr extends RefCnt {
         }
     }
 
+    /**
+     * Controls whether Skia reads gamma and contrast from Windows ClearType settings.
+     *
+     * @param value null  = (-1) use compile-time default (SK_FONT_HOST_USE_SYSTEM_SETTINGS)
+     *              true  = (1) force on  (text matches Windows native rendering)
+     *              false = (0) force off (consistent rendering across machines)
+     */
+    public static void useSystemRenderingParams(Boolean value) {
+        try {
+            Stats.onNativeCall();
+            int intValue = value == null ? -1 : (value ? 1 : 0);
+            _nUseSystemRenderingParams(intValue);
+        } finally {
+            ReferenceUtil.reachabilityFence(value);
+        }
+    }
+
     public static class _DefaultHolder {
         static { Stats.onNativeCall(); }
         public static final FontMgr INSTANCE = new FontMgr(_nDefault(), false);
@@ -199,5 +216,6 @@ public class FontMgr extends RefCnt {
     public static native long _nMatchFamilyStyleCharacter(long ptr, String familyName, int fontStyle, String[] bcp47, int character);
     public static native long _nMakeFromFile(long ptr, String path, int ttcIndex);
     public static native long _nMakeFromData(long ptr, long dataPtr, int ttcIndex);
+    private static native void _nUseSystemRenderingParams(int value);
     public static native long _nDefault();
 }

--- a/tests/java/FontMgrTest.java
+++ b/tests/java/FontMgrTest.java
@@ -1,10 +1,14 @@
 package io.github.humbleui.skija.test;
 
-import static io.github.humbleui.skija.test.runner.TestRunner.assertArrayEquals;
-import static io.github.humbleui.skija.test.runner.TestRunner.assertEquals;
+import static io.github.humbleui.skija.test.runner.TestRunner.*;
 
 import io.github.humbleui.skija.Data;
+import io.github.humbleui.skija.Font;
+import io.github.humbleui.skija.Bitmap;
+import io.github.humbleui.skija.Canvas;
+import io.github.humbleui.skija.FontMgr;
 import io.github.humbleui.skija.FontStyle;
+import io.github.humbleui.skija.Paint;
 import io.github.humbleui.skija.Typeface;
 import io.github.humbleui.skija.paragraph.FontCollection;
 import io.github.humbleui.skija.paragraph.TypefaceFontProvider;
@@ -14,6 +18,11 @@ import io.github.humbleui.skija.test.runner.TestRunner;
 public class FontMgrTest implements Executable {
     @Override
     public void execute() throws Exception {
+         TestRunner.testMethod(this, "base");
+         TestRunner.testMethod(this, "dWriteUseSystemRenderingParams");
+    }
+
+    public void base() {
         // FontManager
         TypefaceFontProvider fm = new TypefaceFontProvider();
         Typeface jbMono = Typeface.makeFromFile("fonts/JetBrainsMono-Regular.ttf", 0);
@@ -89,5 +98,29 @@ public class FontMgrTest implements Executable {
         }
 
         fm.close();
+    }
+
+    public void dWriteUseSystemRenderingParams() {
+
+        Typeface jbMono = Typeface.makeFromFile("fonts/JetBrainsMono-Regular.ttf", 0);
+        Font font = new Font(jbMono, 14);
+
+        try (Bitmap a = new Bitmap(); Paint p = new Paint();) {
+        a.allocN32Pixels(10, 20);
+            try(Canvas canvas = new Canvas(a)) {  
+                assertDoesNotThrow(() -> {        
+                    FontMgr.useSystemRenderingParams(true);
+                    canvas.drawString("Test1", 0, 10, font, p);
+                    FontMgr.useSystemRenderingParams(false);
+                    canvas.drawString("Test2", 0, 20, font, p);
+                    FontMgr.useSystemRenderingParams(null);
+                    canvas.drawString("Test3", 0, 30, font, p);
+                    }
+                );
+            }
+        }
+
+        font.close();
+        jbMono.close();
     }
 }


### PR DESCRIPTION
## Add runtime control for DirectWrite system font rendering params on Windows

### Problem

When `SK_FONT_HOST_USE_SYSTEM_SETTINGS` is defined at compile time, Skia reads
gamma and contrast from Windows ClearType settings via DirectWrite API. While this
makes text match native Windows rendering, it introduces two issues:

- **Cross-wrapper inconsistency**: apps combining Skija with other Skia wrappers
  (e.g. SkiaSharp) that are built without this flag will produce visually different
  text on the same machine
- **Machine-dependent visual testing**: pixel-level regression tests may pass on
  one machine and fail on another due to different ClearType settings

### Solution

Exposes the runtime control introduced in the Skia patch as a public Java API.

### Usage
```java
// use compile-time default (current behavior, no change)
FontMgr.useSystemRenderingParams(null);

// match Windows native rendering (same as SK_FONT_HOST_USE_SYSTEM_SETTINGS)
FontMgr.useSystemRenderingParams(true);

// consistent rendering across machines (e.g. for visual testing or cross-wrapper use)
FontMgr.useSystemRenderingParams(false);
```