### PR TITLE
PDF and SVG annotations

### DIFF
--- a/platform/cc/Canvas.cc
+++ b/platform/cc/Canvas.cc
@@ -5,6 +5,8 @@
 #include "SkSurface.h"
 #include "SkTextBlob.h"
 #include "SkVertices.h"
+#include "SkAnnotation.h"
+#include "SkData.h"
 #include "hb.h"
 #include "interop.hh"
 
@@ -413,4 +415,26 @@ extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_skija_Canvas__1nRestor
 
 extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_skija_Canvas__1nRestoreToCount(JNIEnv* env, jclass jclass, jlong ptr, jint saveCount) {
     reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(ptr))->restoreToCount(saveCount);
+}
+
+static sk_sp<SkData> stringToData(JNIEnv* env, jstring str) {
+    SkString path = *skString(env, str);
+    return SkData::MakeWithCString(path.c_str());
+}
+
+extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_skija_Canvas__1nAnnotateRectWithURL(JNIEnv* env, jclass jclass, jlong ptr, jfloat left, jfloat top, jfloat right, jfloat bottom, jstring urlStr) {
+    SkCanvas* canvas = reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(ptr));
+    SkRect bounds {left, top, right, bottom};
+    SkAnnotateRectWithURL(canvas, bounds, stringToData(env, urlStr).get());
+}
+
+extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_skija_Canvas__1nAnnotateNamedDestination(JNIEnv* env, jclass jclass, jlong ptr, jfloat x, jfloat y, jstring nameStr) {
+    SkCanvas* canvas = reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(ptr));
+    SkAnnotateNamedDestination(canvas, SkPoint::Make(x, y), stringToData(env, nameStr).get());
+}
+
+extern "C" JNIEXPORT void JNICALL Java_io_github_humbleui_skija_Canvas__1nAnnotateLinkToDestination(JNIEnv* env, jclass jclass, jlong ptr, jfloat left, jfloat top, jfloat right, jfloat bottom, jstring nameStr) {
+    SkCanvas* canvas = reinterpret_cast<SkCanvas*>(static_cast<uintptr_t>(ptr));
+    SkRect bounds {left, top, right, bottom};
+    SkAnnotateLinkToDestination(canvas, bounds, stringToData(env, nameStr).get());
 }

--- a/shared/java/Canvas.java
+++ b/shared/java/Canvas.java
@@ -1009,6 +1009,50 @@ public class Canvas extends Managed {
     }
 
     /**
+     * <p>For SVG and PDF backends, makes a link over the rectangle to the specified URL.
+     * Does nothing on other backends.</p>
+     * 
+     * <p>The URL should be properly escaped and be valid 7-bit ASCII.</p>
+     */
+    @NotNull @Contract("_, _ -> this")
+    public Canvas annotateRectWithURL(@NotNull Rect r, @NotNull String url) {
+        assert _ptr != 0 : "Canvas is closed";
+        assert r != null : "Can’t annotateRectWithURL with r == null";
+        assert url != null : "Can’t annotateRectWithURL with url == null";
+        Stats.onNativeCall();
+        _nAnnotateRectWithURL(_ptr, r._left, r._top, r._right, r._bottom, url);
+        return this;
+    }
+
+    /**
+     * <p>For the PDF backend, associates the point with a name that {@link Canvas#annotateLinkToDestination} can make a jump to.</p>
+     * <p>For the SVG backend, functions like {@link Canvas#annotateRectWithURL}.</p>
+     * Does nothing on other backends.
+     */
+    @NotNull @Contract("_, _, _ -> this")
+    public Canvas annotateNamedDestination(float x, float y, @NotNull String name) {
+        assert _ptr != 0 : "Canvas is closed";
+        assert name != null : "Can’t annotateNamedDestination with name == null";
+        Stats.onNativeCall();
+        _nAnnotateNamedDestination(_ptr, x, y, name);
+        return this;
+    }
+
+    /**
+     * For the PDF backend, makes a link over the given rectangle that goes to the respective {@link Canvas#annotateNamedDestination}.
+     * Does nothing on other backends.
+     */
+    @NotNull @Contract("_, _ -> this")
+    public Canvas annotateLinkToDestination(@NotNull Rect r, @NotNull String name) {
+        assert _ptr != 0 : "Canvas is closed";
+        assert r != null : "Can’t annotateLinkToDestination with r == null";
+        assert name != null : "Can’t annotateLinkToDestination with name == null";
+        Stats.onNativeCall();
+        _nAnnotateLinkToDestination(_ptr, r._left, r._top, r._right, r._bottom, name);
+        return this;
+    }
+
+    /**
      * Replaces Matrix with matrix.
      * Unlike concat(), any prior matrix state is overwritten.
      *
@@ -1526,4 +1570,7 @@ public class Canvas extends Managed {
     public static native int  _nGetSaveCount(long ptr);
     public static native void _nRestore(long ptr);
     public static native void _nRestoreToCount(long ptr, int saveCount);
+    public static native void _nAnnotateRectWithURL(long ptr, float left, float top, float right, float bottom, String url);
+    public static native void _nAnnotateNamedDestination(long ptr, float x, float y, String name);
+    public static native void _nAnnotateLinkToDestination(long ptr, float left, float top, float right, float bottom, String name);
 }

--- a/tests/java/DocumentTest.java
+++ b/tests/java/DocumentTest.java
@@ -14,8 +14,12 @@ public class DocumentTest implements Executable {
              Document doc = Document.makePDF(stream)) {
             
             try (Canvas canvas = doc.beginPage(100, 100)) {
+                canvas.annotateNamedDestination(0, 0, "start");
                 Paint paint = new Paint().setColor(0xFFFF0000);
-                canvas.drawRect(Rect.makeXYWH(10, 10, 80, 80), paint);
+                Rect rect = Rect.makeXYWH(10, 10, 80, 80);
+                canvas.drawRect(rect, paint);
+                canvas.annotateRectWithURL(rect, "https://example.org/");
+                canvas.annotateLinkToDestination(Rect.makeXYWH(0, 80, 100, 20), "start");
             }
             doc.endPage();
             doc.close();


### PR DESCRIPTION
Makes it possible to link to pages/sections, and other URLs, in PDFs (and also URLs in SVGs).

I've also got two other tiny commits at https://github.com/dzaima/Skija/commits/dz/; let me know if you want PR(s) for those, or feel free to cherry-pick them in yourself if that's easier. (the package collision thing is especially funky - my PC for whatever reason has `import common` resolve to something (..which even by itself errors immediately, so it probably.. shouldn't exist) which without the fix takes precedence over the `script/common.py`)