### PR TITLE
Handle invalid Unicode inputs better

### DIFF
--- a/platform/cc/interop.cc
+++ b/platform/cc/interop.cc
@@ -1154,13 +1154,10 @@ size_t utfToUtf8(unsigned char *data, size_t len) {
 
         // Six-byte modified UTF-8
         // 11101101    1010xxxx    10xxxxxx    11101101    1011xxxx    10xxxxxx
-        if (byte1 == 0b11101101 && (byte2 & 0b11110000) == 0b10100000) {
-            SkASSERT(read_offset + 5 < len);
-            unsigned char byte4 = data[read_offset + 3];
+        if (byte1 == 0b11101101 && (byte2 & 0b11110000) == 0b10100000 && read_offset + 5 < len && data[read_offset + 3] == 0b11101101) {
             unsigned char byte5 = data[read_offset + 4];
             unsigned char byte6 = data[read_offset + 5];
             SkASSERT((byte3 & 0b11000000) == 0b10000000);
-            SkASSERT(byte4 == 0b11101101);
             SkASSERT((byte5 & 0b11110000) == 0b10110000);
             SkASSERT((byte6 & 0b11000000) == 0b10000000);
             uint32_t codepoint = (((byte2 & 0b00001111) << 16) |

--- a/shared/java/Font.java
+++ b/shared/java/Font.java
@@ -460,6 +460,7 @@ public class Font extends Managed {
      * @return   the bounding box of text
      */
     public Rect measureText(String s, Paint p) {
+        assert _validUTF16(s) : "Can’t measureText with invalid UTF-16";
         try {
             Stats.onNativeCall();
             return _nMeasureText(_ptr, s, Native.getPtr(p));
@@ -475,6 +476,7 @@ public class Font extends Managed {
     }
 
     public float measureTextWidth(String s, Paint p) {
+        assert _validUTF16(s) : "Can’t measureTextWidth with invalid UTF-16";
         try {
             Stats.onNativeCall();
             return _nMeasureTextWidth(_ptr, s, Native.getPtr(p));
@@ -627,6 +629,19 @@ public class Font extends Managed {
     @ApiStatus.Internal
     public static class _FinalizerHolder {
         public static final long PTR = _nGetFinalizer();
+    }
+
+    @ApiStatus.Internal
+    public boolean _validUTF16(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (Character.isSurrogate(c)) {
+                if (i + 1 >= s.length() || !Character.isSurrogatePair(c, s.charAt(i + 1)))
+                    return false;
+                i++;
+            }
+        }
+        return true;
     }
 
     @ApiStatus.Internal public static native long    _nGetFinalizer();


### PR DESCRIPTION
The places using `GetStringRegion` or `GetStringCritical` are:
- `Font::getStringGlyphsCount` (which seems to gracefully handle bad UTF-16 by returning `-1`);
- `U16String`, just copying them around
- `Font::measureText`, `Font::measureTextWidth`, which are problematic - Skia seems to segfault on e.g. `font.measureText("\ud835")`; fix these by asserting that the input is valid UTF-16.

(perhaps it'd make sense to expose `validUTF16` to the user? there's no general utilities class though, though perhaps `U16String` could be (ab)used for this)

---

And `skString` is the only place using `GetStringUTFRegion`; `utfToUtf8` ends up doing out-of-bounds reads & a write on e.g. an input of `"\ud835"` (input is 3 bytes, but `utfToUtf8` assumes it's a 6-byte sequence, and writes 4 bytes); and e.g. `canvas.drawString("\ud835X\ud835",...)` ends up in an infinite loop, with the first char trying to incorrectly consume 6 bytes (itself's 3 bytes, 1 byte of `X`, and two bytes of the third char) leaving it parsing mid-char with a `byte1` bit pattern `0x10XXXXXX` that isn't matched by anything.

Fix these by validating the 6-byte "sequence" more (doesn't fully validate that the second char is a matching surrogate pair, but does enough to make sure to not read/write out-of-bounds or desynchronize the parsing). Might make sense to rewrite it entirely to go directly from `GetStringCritical` to not have two rounds of conversions (and handle wrong inputs better), but I wanted something minimal for now.