### PR TITLE
Update to HumbleUI/Types 0.2.0

### DIFF
--- a/shared/deploy/META-INF/maven/io.github.humbleui/skija-shared/pom.xml
+++ b/shared/deploy/META-INF/maven/io.github.humbleui/skija-shared/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>io.github.humbleui</groupId>
             <artifactId>types</artifactId>
-            <version>0.1.1</version>
+            <version>0.2.0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Skija compiles for Java 8, but depends on Types 0.1.1 which was compiled for Java 9.


Updating to 0.2.0 (see https://github.com/HumbleUI/Types/pull/2) will allow Skija to just work on Java 8 without requiring a manual transitive dependency upgrade.