### PR TITLE
Chain errors in release

### DIFF
--- a/script/build_utils.py
+++ b/script/build_utils.py
@@ -370,7 +370,7 @@ def release(zip_name, target_dir):
   except urllib.error.HTTPError as e:
     error_data = e.read().decode('utf-8') if e.fp else str(e)
     print(f"Upload failed: {e.code} - {error_data}")
-    raise Exception(f"Failed to upload to Sonatype Central: {e.code} - {error_data}")
+    raise Exception(f"Failed to upload to Sonatype Central: {e.code} - {error_data}") from e
 
   # Check deployment status
   deployment_id = response_data


### PR DESCRIPTION
There might be a small issue in release: The wrapper exception drops the original cause. this patch chains it with from so the real failure still shows up in tracebacks. Let me know if I’m missing context.
Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.