### PR TITLE
Fix empty strings being considered as invalid

### DIFF
--- a/platform/cc/interop.cc
+++ b/platform/cc/interop.cc
@@ -1102,7 +1102,7 @@ const SkUnichar* skija::ConvertToUTF32::convert(JNIEnv* env, jstring str) {
     const jchar* chars = env->GetStringCritical(str, nullptr);
     const uint16_t* src = reinterpret_cast<const uint16_t*>(chars);
     const uint16_t* end = src + len;
-    SkUnichar* dst = fStorage.reset(len);
+    SkUnichar* dst = fStorage.reset(std::max(len, 1));
     int n = 0;
     while (src < end) {
         SkUnichar u = SkUTF::NextUTF16(&src, end);

--- a/tests/java/FontTest.java
+++ b/tests/java/FontTest.java
@@ -1,6 +1,7 @@
 package io.github.humbleui.skija.test;
 
 import io.github.humbleui.skija.*;
+import io.github.humbleui.types.Rect;
 import io.github.humbleui.skija.test.runner.*;
 
 import static io.github.humbleui.skija.test.runner.TestRunner.*;
@@ -13,6 +14,12 @@ public class FontTest implements Executable {
 
             float advance = font.measureTextWidth("a");
 
+            // Empty strings
+            assertEquals(0.0f, font.measureTextWidth(""));
+            assertEquals(0, font.getStringGlyphs("").length);
+            assertEquals(0, font.getStringGlyphsCount(""));
+            assertEquals(Rect.makeLTRB(0, 0, 0, 0), font.measureText(""));
+            
             // ASCII
             assertClose(3 * advance, font.measureTextWidth("abc"), 0.01f);
 


### PR DESCRIPTION
fixes #112

(some fix alternatives would be returning a `std::optional` or returning a pointer to some random scratch memory, but this option seemed simple enough)