### PR TITLE
support build for Windows Arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,23 +117,34 @@ jobs:
           path: target/skija-android-${{ matrix.arch }}-*
 
   build_windows:
-    runs-on: windows-2022
+    strategy:
+      matrix:
+        os: [ windows-2022, windows-11-arm ]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: microsoft/setup-msbuild@v1
+      - uses: actions/checkout@v6
+      - run: |
+          $os_arch = "${{ runner.arch }}".ToLower()
+          echo "os_arch=$os_arch" >> $env:GITHUB_ENV
+      - uses: microsoft/setup-msbuild@v3
+        with:
+          msbuild-architecture: ${{ env.os_arch }}
       - uses: ilammy/msvc-dev-cmd@v1
-      - shell: bash
-        run: |
-          echo "JAVA_HOME=$JAVA_HOME_11_X64" >> $GITHUB_ENV
-          echo "$JAVA_HOME_11_X64/bin" >> $GITHUB_PATH
+        with:
+          arch: ${{ env.os_arch }}
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'microsoft'
+          java-version: '11'
       - run: python3 script/build.py
       - shell: bash
         run: python3 script/test.py
       - run: python3 script/package_platform.py
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
-          name: windows-x64-jars
-          path: target/skija-windows-x64-*
+          name: windows-${{ env.os_arch }}-jars
+          path: target/skija-windows-${{ env.os_arch }}-*
 
   release:
     if: startsWith(github.ref, 'refs/tags/')

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -81,7 +81,7 @@ elseif(WIN32)
     # set_property(TARGET skija PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")
     set(CMAKE_CXX_FLAGS_RELEASE "/MT")
     set(CMAKE_CXX_FLAGS_DEBUG "/MTd")
-    target_link_options(skija PRIVATE /INCREMENTAL:NO /NODEFAULTLIB:MSVCRT /machine:X64)
+    target_link_options(skija PRIVATE /INCREMENTAL:NO /NODEFAULTLIB:MSVCRT)
 endif()
 
 target_link_libraries(skija skottie sksg svg skparagraph skshaper skunicode skresources skia ${FREETYPE_LIBRARIES} ${HARFBUZZ_LIBRARIES})

--- a/script/build_utils.py
+++ b/script/build_utils.py
@@ -9,7 +9,7 @@ def get_arg(name):
   return vars(args).get(name.replace("-", "_"))
 
 execdir = os.getcwd()
-native_arch = {'AMD64': 'x64', 'x86_64': 'x64', 'arm64': 'arm64', 'aarch64': 'arm64'}[platform.machine()]
+native_arch = {'amd64': 'x64', 'x86_64': 'x64', 'arm64': 'arm64', 'aarch64': 'arm64'}[platform.machine().lower()]
 arch   = get_arg("arch")   or native_arch
 system = get_arg("system") or {'Darwin': 'macos', 'Linux': 'linux', 'Windows': 'windows'}[platform.system()]
 classpath_separator = ';' if platform.system() == 'Windows' else ':'


### PR DESCRIPTION
Adding build for Windows Arm64, by adding a build runner for `windows-11-arm` in `buid.yml` workflow, plus various little changes to support Skija build for Windows Arm64.

Note that this PR depends on the SkiaBuild's PR [#16](https://github.com/HumbleUI/SkiaBuild/pull/16) be merged and a new SkiaBuild release be made to include new Skia libs for Windows Arm64 there.